### PR TITLE
Fixing the guidedStart flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,6 @@ Open-source bots for traders and activists in the [Rubicon](https://docs.rubicon
 
 Welcome to `rubi-bots`! This repository hosts open-source market-making, liquidator, and arbitrage bots for traders and activists in the Rubicon ecosystem. With a focus on improving performance and growing the Rubicon ecosystem together, `rubi-bots` serves as a one-stop shop for traders and activists, providing potential profit opportunities, learning resources, and avenues for technical improvement.
 
-# TODO
-1. links to learn about market aids and what they are
-2. blurb and further reading on the different strategies
-3. blurb and further reading on the different bots 
-
 This repository has two main commands for users 
 1. `guidedStart` - the quickest way to get started with Rubicon and deploy a bot
 2. `aid` - this command allows you to manage your aid (deposits, withdrawls, etc) 
@@ -47,7 +42,7 @@ To get started with `rubi-bots`, follow these steps:
 4. Choose between the following mainnet/testnet 
 - ✅ Optimism Mainnet/Goerli
 - ❌ Arbitrum Mainnet/Goerli [WIP]
-- ✅ Polygon Mainnet/Mumbai
+- ❌/✅ Polygon Mainnet/Mumbai
 5. Based on your selection, you have certain available tokens for your strategy
 - Enter the tokens you want and enter `done` when finished
 6. If you have an existing `MarketAid` address, enter it here. Otherwise, enter `no` to start the creation process
@@ -67,7 +62,7 @@ To get started with `rubi-bots`, follow these steps:
 2. Choose between the following mainnet/testnets to generate your aid
 - ❌/✅ Optimism Mainnet/Goerli [WIP]
 - ❌ Arbitrum Mainnet/Goerli [WIP]
-- ✅ Polygon Mainnet/Mumbai
+- ❌/✅ Polygon Mainnet/Mumbai
 3. The aid menu will open allowing you to:
 - Connect to an existing aid
 - View existing aids
@@ -84,6 +79,11 @@ Contributions to rubi-bots are welcome and encouraged!
 
 ## License
 This project is licensed under the MIT License.
+
+# Further Reading
+- Learn more about [MarketAids](https://docs.rubicon.finance/protocol/rubicon-market/market-aid)
+- Different [trading strategies] supported
+- Different [bots] supported
 
 ## Risk Disclaimers
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,111 @@
-# EXPERIMENTAL AND IN DEVELOPMENT - USE AT YOUR OWN RISK
-
 # rubi-bots
-Open-source bots for activists in the Rubicon ecosystem
+Open-source bots for traders and activists in the Rubicon ecosystem
 
-## Welcome
-Welcome to `rubi-bots`! This repo is for operating bots on Rubicon for potential profits, learning, and tech improvement. Currently offering market-making bots, with liquidator and arbitrage bots coming soon. A one-stop shop for traders and activists to improve performance and grow the Rubicon ecosystem together.
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/RubiconDeFi/rubi-bots/blob/main/LICENSE)
+[![GitHub Stars](https://img.shields.io/github/stars/RubiconDeFi/rubi-bots.svg)](https://github.com/RubiconDeFi/rubi-bots/stargazers)
+[![GitHub Issues](https://img.shields.io/github/issues/RubiconDeFi/rubi-bots.svg)](https://github.com/RubiconDeFi/rubi-bots/issues)
+[![GitHub Forks](https://img.shields.io/github/forks/RubiconDeFi/rubi-bots.svg)](https://github.com/RubiconDeFi/rubi-bots/network)
 
-## Quickstart
-1. Clone this repo to your machine `gh repo clone RubiconDeFi/rubi-bots`
-2. Start a terminal session in that repo `cd rubi-bots`
-3. Download dependencies `yarn install`
-4. Launch Guided Start `yarn run guidedStart`
+## Description
 
-## Target bots and strategies to build/release:
-- [WIP] Riskless MM strategy - AMM Up Only
-- [WIP] Competitive MM strategy - AMM Out Bid
-- [] Two Venue Arbitrage - Rubi vs Selected Venue
-- [] v2 Liduidator Bot - Money Market Activist
+Welcome to `rubi-bots`! This repository hosts open-source market-making, liquidator, and arbitrage bots for traders and activists in the Rubicon ecosystem. With a focus on improving performance and growing the Rubicon ecosystem together, `rubi-bots` serves as a one-stop shop for traders and activists, providing potential profit opportunities, learning resources, and avenues for technical improvement.
+
+include some information about
+1. market aids
+2. the different strategies
+3. the different bots 
+
+This repository has two main commands for users 
+1. `guidedStart` - the quickest way to get started with Rubicon and deploy a bot
+2. `aid` - this command allows you to manage your aid (deposits, withdrawls, etc) 
+
+## Get started
+
+To get started with `rubi-bots`, follow these steps:
+
+1. Clone this repository to your machine:
+    ```shell
+        gh repo clone RubiconDeFi/rubi-bots
+2. Navigate to the cloned repository:
+    ```shell
+        cd rubi-bots
+3. Download the project dependencies:
+    ```shell
+        npm install
+    ```
+## Run the guided start 
+1. Run the command 
+    ```shell
+        npm run guidedStart
+2. Choose between the following 3 bots 
+- ✅ Market-Making Bot
+- ❌ Trading Bot [WIP]
+- ❌ Liquidator Bot [WIP]
+3. Choose between the following 2 strategies
+- ✅ Risk Minimized Up Only
+- ✅ Target Venue Out Bid
+4. Choose between the following mainnet/testnet 
+- ✅ Optimism Mainnet/Goerli
+- ❌ Arbitrum Mainnet/Goerli [WIP]
+- ✅ Polygon Mainnet/Mumbai
+5. Based on your selection, you have certain available tokens for your strategy
+- Enter the tokens you want and enter `done` when finished
+6. If you have an existing `MarketAid` address, enter it here. Otherwise, enter `no` to start the creation process
+7. Both options will open up an aid menu where you can manage your aid 
+- View Market Aid Info
+- Check if you are approved 
+- View your balances for tokens
+- Deposit to the aid
+- Withdraw from the aid
+- Pull all funds
+8. After managing, a final prompt asks you to confirm before the strategy executes
+
+## Run the aid management 
+1. Run the command 
+    ```shell
+        npm run aid
+2. Choose between the following mainnet/testnets to generate your aid
+- ✅ Optimism Mainnet/Goerli
+- ❌ Arbitrum Mainnet/Goerli [WIP]
+- ✅ Polygon Mainnet/Mumbia
+
+
+Copy code
+yarn run guidedStart
+Target Bots and Strategies to Build/Release
+
+[WIP] Riskless MM strategy - AMM Up Only
+[WIP] Competitive MM strategy - AMM Out Bid
+ Two Venue Arbitrage - Rubi vs Selected Venue
+ v2 Liquidator Bot - Money Market Activist
+
+## Aid
+
+Contributing
+
+Contributions to rubi-bots are welcome and encouraged! If you would like to contribute, please follow the guidelines outlined in CONTRIBUTING.md.
+
+License
+
+This project is licensed under the MIT License.
+
+Acknowledgements
+
+We would like to acknowledge the following resources and individuals for their contributions and support:
+
+Resource 1
+Resource 2
+Contributor 1
+Contributor 2
+
+## Risk Disclaimers
+
+**Experimental and in Development - Use at your own risk**
+
+### Rubi-Bots Disclaimer
+
+This codebase is in Alpha is experimental and in development. It could contain bugs or change significantly between versions. Contributing through Issues or Pull Requests is welcome!
+
+### Protocol Disclaimer
+
+Please refer to [this](https://docs.rubicon.finance/docs/protocol/rubicon-pools/risks) for information on the risks associated to the Rubicon Protocol.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Contributions to rubi-bots are welcome and encouraged!
 ## License
 This project is licensed under the MIT License.
 
-# Further Reading
+## Further Reading
 - Learn more about [MarketAids](https://docs.rubicon.finance/protocol/rubicon-market/market-aid)
 - Different [trading strategies] supported
 - Different [bots] supported

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ This project is licensed under the MIT License.
 
 ## Further Reading
 - Learn more about [MarketAids](https://docs.rubicon.finance/protocol/rubicon-market/market-aid)
-- Different [trading strategies] supported
-- Different [bots] supported
+- Learn more about the [Rubicon protocol](https://docs.rubicon.finance)
+- View the rest of our [codebase](https://github.com/RubiconDeFi/rubi-protocol-v2)
 
 ## Risk Disclaimers
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # rubi-bots
-Open-source bots for traders and activists in the Rubicon ecosystem
+Open-source bots for traders and activists in the [Rubicon](https://docs.rubicon.finance/docs/protocol) ecosystem
 
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/RubiconDeFi/rubi-bots/blob/main/LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/RubiconDeFi/rubi-bots.svg)](https://github.com/RubiconDeFi/rubi-bots/stargazers)
@@ -10,10 +10,10 @@ Open-source bots for traders and activists in the Rubicon ecosystem
 
 Welcome to `rubi-bots`! This repository hosts open-source market-making, liquidator, and arbitrage bots for traders and activists in the Rubicon ecosystem. With a focus on improving performance and growing the Rubicon ecosystem together, `rubi-bots` serves as a one-stop shop for traders and activists, providing potential profit opportunities, learning resources, and avenues for technical improvement.
 
-include some information about
-1. market aids
-2. the different strategies
-3. the different bots 
+# TODO
+1. links to learn about market aids and what they are
+2. blurb and further reading on the different strategies
+3. blurb and further reading on the different bots 
 
 This repository has two main commands for users 
 1. `guidedStart` - the quickest way to get started with Rubicon and deploy a bot
@@ -65,38 +65,25 @@ To get started with `rubi-bots`, follow these steps:
     ```shell
         npm run aid
 2. Choose between the following mainnet/testnets to generate your aid
-- ✅ Optimism Mainnet/Goerli
+- ❌/✅ Optimism Mainnet/Goerli [WIP]
 - ❌ Arbitrum Mainnet/Goerli [WIP]
-- ✅ Polygon Mainnet/Mumbia
+- ✅ Polygon Mainnet/Mumbai
+3. The aid menu will open allowing you to:
+- Connect to an existing aid
+- View existing aids
+- Create a new aid
 
+## Target Bots and Strategies to Build/Release
+- [WIP] Riskless MM strategy - AMM Up Only
+- [WIP] Competitive MM strategy - AMM Out Bid
+- Two Venue Arbitrage - Rubi vs Selected Venue
+- v2 Liquidator Bot - Money Market Activist
 
-Copy code
-yarn run guidedStart
-Target Bots and Strategies to Build/Release
+## Contributing
+Contributions to rubi-bots are welcome and encouraged! 
 
-[WIP] Riskless MM strategy - AMM Up Only
-[WIP] Competitive MM strategy - AMM Out Bid
- Two Venue Arbitrage - Rubi vs Selected Venue
- v2 Liquidator Bot - Money Market Activist
-
-## Aid
-
-Contributing
-
-Contributions to rubi-bots are welcome and encouraged! If you would like to contribute, please follow the guidelines outlined in CONTRIBUTING.md.
-
-License
-
+## License
 This project is licensed under the MIT License.
-
-Acknowledgements
-
-We would like to acknowledge the following resources and individuals for their contributions and support:
-
-Resource 1
-Resource 2
-Contributor 1
-Contributor 2
 
 ## Risk Disclaimers
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Open-source bots for traders and activists in the [Rubicon](https://docs.rubicon
 
 ## Description
 
-Welcome to `rubi-bots`! This repository hosts open-source market-making, liquidator, and arbitrage bots for traders and activists in the Rubicon ecosystem. With a focus on improving performance and growing the Rubicon ecosystem together, `rubi-bots` serves as a one-stop shop for traders and activists, providing potential profit opportunities, learning resources, and avenues for technical improvement.
+Welcome to `rubi-bots`! This repository hosts open-source market-making, liquidator, and arbitrage bots in the Rubicon ecosystem. With a focus on improving performance and growing the Rubicon ecosystem together, `rubi-bots` serves as a one-stop shop for potential profit opportunities, learning resources, and avenues for technical improvement.
 
 This repository has two main commands for users 
 1. `guidedStart` - the quickest way to get started with Rubicon and deploy a bot

--- a/configuration/index.ts
+++ b/configuration/index.ts
@@ -76,10 +76,10 @@ async function marketMakingStrategyCallback(): Promise<MarketMakingStrategy> {
 // Function that asks the user what ETH L2 Network they want to use for their selected strategy, takes user command line input to get their answer after displaying options
 async function networkCallback(): Promise<Network> {
     return new Promise(resolve => {
-        rl.question('\n What network would you like to execute this strategy on?\n1. Optimism Mainnet\n2. Optimism Goerli\n3. Arbitrum Mainnet\n4. Arbitrum Goerli\n:', (answer) => {
+        rl.question('\n What network would you like to execute this strategy on?\n1. Optimism Mainnet\n2. Optimism Goerli\n3. Arbitrum Mainnet\n\n4. Arbitrum Goerli\n5. Polygon Mainnet\n6. Polygon Mumbai\n:', (answer) => {
             switch (answer.toLowerCase()) {
                 case '1':
-                    console.log('\n Selected Optimism');
+                    console.log('\n Selected Optimism Mainnet');
                     resolve(Network.OPTIMISM_MAINNET);
                     break;
                 case '2':
@@ -87,12 +87,20 @@ async function networkCallback(): Promise<Network> {
                     resolve(Network.OPTIMISM_GOERLI);
                     break;
                 case '3':
-                    console.log('\n Selected Arbitrum');
+                    console.log('\n Selected Arbitrum Mainnet');
                     resolve(Network.ARBITRUM_MAINNET);
                     break;
                 case '4':
                     console.log('\n Selected Arbitrum Goerli');
                     resolve(Network.ARBITRUM_TESTNET);
+                    break;
+                case '5':
+                    console.log('\n Selected Polygon Mainnet');
+                    resolve(Network.POLYGON_MAINNET);
+                    break;
+                case '6':
+                    console.log('\n Selected Polygon Mumbai');
+                    resolve(Network.POLYGON_MUMBAI);
                     break;
                 default:
                     console.log('Invalid answer! Pick a number 1 through 4');

--- a/configuration/index.ts
+++ b/configuration/index.ts
@@ -120,7 +120,7 @@ async function tokenSelectionCallback(network: Network): Promise<TokenInfo[]> {
         // Prompt the user to select tokens based on their symbol from availableTokensSymbols
         console.log("These are the available tokens on your selected Network: ", availableTokensSymbols);
 
-        // TODO: strateyg-specific UX flow here or warnings?? e.g. pair-based strategies
+        // TODO: strateyg-specific UX flow here or warnings?? e.g. pair-based strategies. Also maybe let user type in space deliminated tokens in 1 line
         // after done is input, return the selectedTokens array
         rl.question('\n What tokens would you like to target in your strategy? (Enter the symbol of the token you want to target then enter to add, or enter "done" to finish):', (answer) => {
             if (answer.toLowerCase() === 'done') {

--- a/configuration/index.ts
+++ b/configuration/index.ts
@@ -163,7 +163,6 @@ async function main() {
                 // 2. What strategy would you like to employ?
                 return marketMakingStrategyCallback().then((selectedStrat: MarketMakingStrategy) => {
                     console.log("The user selected this market-making strategy", selectedStrat);
-
                     // Conceptually we know that they want to do now, but we need to know what tokens they want to target, what network they want to target, etc. = configuration
                     // 3. What network(s) would you like to execute this strategy on?
                     return networkCallback().then(async (selectedNetwork: Network) => {

--- a/configuration/index.ts
+++ b/configuration/index.ts
@@ -9,14 +9,10 @@ import { TokenInfo } from "@uniswap/token-lists";
 import { BotConfiguration, BotType, ETH_ZERO_ADDRESS, MarketMakingStrategy, Network, tokenList } from "./config";
 import { startGenericMarketMakingBot } from "../executionClients/marketMaking";
 import { ethers } from "ethers";
-dotenv.config();
 
-// 5. Start
-const readline = require('node:readline');
-let rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout
-});
+// importing the readline from marketaid 
+import { rl } from "./marketAid"
+dotenv.config();
 
 async function botTypeUserCallback(): Promise<BotType> {
     return new Promise(async (resolve) => {

--- a/configuration/marketAid.ts
+++ b/configuration/marketAid.ts
@@ -829,7 +829,7 @@ async function main(): Promise<void> {
     }
 }
 
-export {rl, getTokensByNetwork, getAidFactory, switchNetwork, maxApproveMarketAidForAllTokens, depositMenu, aidFactoryMenu, networkMenu}
+export {rl, getTokensByNetwork, getAidFactory, switchNetwork, maxApproveMarketAidForAllTokens, depositMenu, aidFactoryMenu, networkMenu, getTokenBalances}
 
 if (require.main === module) {
     main();

--- a/configuration/marketAid.ts
+++ b/configuration/marketAid.ts
@@ -266,6 +266,10 @@ async function depositMenu(marketAid: MarketAid, rl): Promise<void> {
                 });
             } else if (selectedIndex === tokens.length) {
                 console.log("\nDeposit summary:");
+                if (depositAssets.length === 0) {
+                    console.log("No assets selected to deposit. Exiting deposit menu.");
+                    aidMenu(marketAid) // Exit back to menu
+                }
                 depositAssets.forEach((asset, index) => {
                     const token = tokens.find((t) => t.address === asset);
                     if (token) {

--- a/configuration/marketAid.ts
+++ b/configuration/marketAid.ts
@@ -8,6 +8,7 @@ import { BotConfiguration, OnChainBookWithData, SimpleBook, StrategistTrade, mar
 import { ERC20 } from "../utilities/contracts/ERC20";
 import { MarketAid } from "../utilities/contracts/MarketAid" 
 import { MarketAidFactory } from "../utilities/contracts/MarketAidFactory"
+import { escape } from "querystring";
 
 dotenv.config();
 
@@ -88,7 +89,8 @@ function getTokensByNetwork(network: Network): TokenInfo[] {
  * @throws an error if no market aid factory address is found for the network 
  */
 // TODO: instead of throwing an error, prompt the user to choose a different network
-function getAidFactory(network: Network, signer: ethers.Signer): MarketAidFactory {
+// i have an idea for this but it requires changing up the networkMenu code I think...
+export function getAidFactory(network: Network, signer: ethers.Signer): MarketAidFactory {
 
     const factoryAddress = marketAidFactoriesByNetwork[network];
   
@@ -628,7 +630,7 @@ async function aidMenu(marketAid: MarketAid): Promise<void> {
 }
 
 // a market aid factory menu, set the aid instance variable upon selection, or returns to the network menu. takes a market aid factory as a parameter
-async function aidFactoryMenu(marketAidFactory: MarketAidFactory): Promise<void> {
+export async function aidFactoryMenu(marketAidFactory: MarketAidFactory): Promise<void> {
     console.log("\nMarket Aid Factory Menu");
     console.log("");
     console.log("1. Connect to an existing Market Aid");
@@ -705,7 +707,7 @@ async function aidFactoryMenu(marketAidFactory: MarketAidFactory): Promise<void>
 
 
 // a network selection menu, set the network variable and current market aid factory upon selection
-async function networkMenu(): Promise<void> {
+export async function networkMenu(): Promise<void> {
     console.log("\nNetwork Selection Menu");
     console.log("");
     console.log("Mainnets:");
@@ -817,7 +819,6 @@ async function networkMenu(): Promise<void> {
 async function main(): Promise<void> {
 
     try { 
-
         // 1. ask the user what network they want to use to manage their market aid instance
         networkMenu();
 

--- a/configuration/marketAid.ts
+++ b/configuration/marketAid.ts
@@ -829,7 +829,7 @@ async function main(): Promise<void> {
     }
 }
 
-export {rl, getTokensByNetwork, getAidFactory, switchNetwork, maxApproveMarketAidForAllTokens, depositMenu, aidFactoryMenu, networkMenu, getTokenBalances}
+export {rl, getTokensByNetwork, getAidFactory, switchNetwork, maxApproveMarketAidForAllTokens, depositMenu, aidFactoryMenu, networkMenu, getTokenBalances, withdrawAllTokens}
 
 if (require.main === module) {
     main();

--- a/configuration/marketAid.ts
+++ b/configuration/marketAid.ts
@@ -23,7 +23,7 @@ let tokens: TokenInfo[] = [];
 let erc20Tokens: ERC20[] = [];
 
 const readline = require('node:readline');
-let rl = readline.createInterface({
+export let rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout
 });
@@ -77,7 +77,7 @@ function getNetworkInfo(network: Network): { jsonRpcProvider: ethers.providers.J
  * @param network the network object to get the token list for
  * @returns the token list for the network
  */
-function getTokensByNetwork(network: Network): TokenInfo[] {
+export function getTokensByNetwork(network: Network): TokenInfo[] {
     return tokenList.tokens.filter((token) => token.chainId === network);
 }
 
@@ -107,7 +107,7 @@ export function getAidFactory(network: Network, signer: ethers.Signer): MarketAi
  * @param newNetwork the network object to update the network, tokens, and erc20Tokens variables for
  * @returns void
  */ 
-async function switchNetwork(newNetwork: Network) {
+export async function switchNetwork(newNetwork: Network) {
     network = newNetwork;
     tokens = getTokensByNetwork(network);
   
@@ -170,7 +170,7 @@ async function getTokenBalances(address: string) {
  * @returns An array of transaction receipts.
  */
 // TODO: all of these calls should be batched into a single transaction
-async function maxApproveMarketAidForAllTokens(tokens: ERC20[], marketAid: MarketAid, signer: Signer): Promise<string> {
+export async function maxApproveMarketAidForAllTokens(tokens: ERC20[], marketAid: MarketAid, signer: Signer): Promise<string> {
     // const maxApprovals: ethers.ContractTransaction[] = [];
 
     for (const token of tokens) {
@@ -242,10 +242,10 @@ async function selectExistingMarketAid(aidCheck: string[]): Promise<string> {
 }
 
 // a menu to assist with depositing assets into a market aid
-async function depositMenu(marketAid: MarketAid): Promise<void> {
+export async function depositMenu(marketAid: MarketAid, rl): Promise<void> {
     const depositAssets: string[] = [];
     const depositAmounts: BigNumber[] = [];
-
+    console.log("break")
     const addAssetToDeposit = async () => {
         console.log("\nSelect an asset to deposit:");
         tokens.forEach((token, index) => {
@@ -531,7 +531,7 @@ async function aidMenu(marketAid: MarketAid): Promise<void> {
                 });
 
                 // Implement deposit functionality here
-                await depositMenu(marketAid);
+                await depositMenu(marketAid, rl);
                 // await aidMenu(marketAid);
                 break;
         

--- a/configuration/marketAid.ts
+++ b/configuration/marketAid.ts
@@ -1,10 +1,8 @@
 import * as dotenv from "dotenv";
-
 import { ethers, Signer, BigNumber } from "ethers";
 import { TokenInfo } from "@uniswap/token-lists";
 import { tokenList } from "../configuration/config";
 import { BotConfiguration, OnChainBookWithData, SimpleBook, StrategistTrade, marketAddressesByNetwork, Network, marketAidFactoriesByNetwork } from "../configuration/config";
-
 import { ERC20 } from "../utilities/contracts/ERC20";
 import { MarketAid } from "../utilities/contracts/MarketAid" 
 import { MarketAidFactory } from "../utilities/contracts/MarketAidFactory"
@@ -23,7 +21,7 @@ let tokens: TokenInfo[] = [];
 let erc20Tokens: ERC20[] = [];
 
 const readline = require('node:readline');
-export let rl = readline.createInterface({
+let rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout
 });
@@ -77,7 +75,7 @@ function getNetworkInfo(network: Network): { jsonRpcProvider: ethers.providers.J
  * @param network the network object to get the token list for
  * @returns the token list for the network
  */
-export function getTokensByNetwork(network: Network): TokenInfo[] {
+function getTokensByNetwork(network: Network): TokenInfo[] {
     return tokenList.tokens.filter((token) => token.chainId === network);
 }
 
@@ -90,7 +88,7 @@ export function getTokensByNetwork(network: Network): TokenInfo[] {
  */
 // TODO: instead of throwing an error, prompt the user to choose a different network
 // i have an idea for this but it requires changing up the networkMenu code I think...
-export function getAidFactory(network: Network, signer: ethers.Signer): MarketAidFactory {
+function getAidFactory(network: Network, signer: ethers.Signer): MarketAidFactory {
 
     const factoryAddress = marketAidFactoriesByNetwork[network];
   
@@ -107,7 +105,7 @@ export function getAidFactory(network: Network, signer: ethers.Signer): MarketAi
  * @param newNetwork the network object to update the network, tokens, and erc20Tokens variables for
  * @returns void
  */ 
-export async function switchNetwork(newNetwork: Network) {
+async function switchNetwork(newNetwork: Network) {
     network = newNetwork;
     tokens = getTokensByNetwork(network);
   
@@ -170,7 +168,7 @@ async function getTokenBalances(address: string) {
  * @returns An array of transaction receipts.
  */
 // TODO: all of these calls should be batched into a single transaction
-export async function maxApproveMarketAidForAllTokens(tokens: ERC20[], marketAid: MarketAid, signer: Signer): Promise<string> {
+async function maxApproveMarketAidForAllTokens(tokens: ERC20[], marketAid: MarketAid, signer: Signer): Promise<string> {
     // const maxApprovals: ethers.ContractTransaction[] = [];
 
     for (const token of tokens) {
@@ -242,7 +240,7 @@ async function selectExistingMarketAid(aidCheck: string[]): Promise<string> {
 }
 
 // a menu to assist with depositing assets into a market aid
-export async function depositMenu(marketAid: MarketAid, rl): Promise<void> {
+async function depositMenu(marketAid: MarketAid, rl): Promise<void> {
     const depositAssets: string[] = [];
     const depositAmounts: BigNumber[] = [];
     console.log("break")
@@ -630,7 +628,7 @@ async function aidMenu(marketAid: MarketAid): Promise<void> {
 }
 
 // a market aid factory menu, set the aid instance variable upon selection, or returns to the network menu. takes a market aid factory as a parameter
-export async function aidFactoryMenu(marketAidFactory: MarketAidFactory): Promise<void> {
+async function aidFactoryMenu(marketAidFactory: MarketAidFactory): Promise<void> {
     console.log("\nMarket Aid Factory Menu");
     console.log("");
     console.log("1. Connect to an existing Market Aid");
@@ -707,7 +705,7 @@ export async function aidFactoryMenu(marketAidFactory: MarketAidFactory): Promis
 
 
 // a network selection menu, set the network variable and current market aid factory upon selection
-export async function networkMenu(): Promise<void> {
+async function networkMenu(): Promise<void> {
     console.log("\nNetwork Selection Menu");
     console.log("");
     console.log("Mainnets:");
@@ -826,6 +824,8 @@ async function main(): Promise<void> {
         console.log(error);
     }
 }
+
+export {rl, getTokensByNetwork, getAidFactory, switchNetwork, maxApproveMarketAidForAllTokens, depositMenu, aidFactoryMenu, networkMenu}
 
 if (require.main === module) {
     main();

--- a/executionClients/marketMaking/index.ts
+++ b/executionClients/marketMaking/index.ts
@@ -442,6 +442,10 @@ export async function startGenericMarketMakingBot(configuration: BotConfiguratio
 
     if (userMarketAidAddress != "no") {
         console.log("The user selected to use an existing contract instance", userMarketAidAddress);
+        const marketAidForExisting = new MarketAid(userMarketAidAddress, configuration.connections.signer);
+        console.log("Opening menu for aid management...");
+        await aidMenu(tokens, configuration, marketAidForExisting) 
+        
         marketAidContractInstance = new ethers.Contract(userMarketAidAddress, MARKET_AID_INTERFACE, myProvider);
         console.log("\n This is my contract's address: ", marketAidContractInstance.address);
 

--- a/executionClients/marketMaking/index.ts
+++ b/executionClients/marketMaking/index.ts
@@ -351,6 +351,21 @@ async function helpUserCreateNewMarketAidInstance(configuration: BotConfiguratio
     return { newMarketAidAddress, marketAid };
 }
 
+// callback function confirming you want to start the bot 
+function userConfirmStart(rl: any, userMarketAidAddress: string): Promise<string> {
+    return new Promise(resolve => {
+        rl.question('\n Do you want to start this strategy (yes/no):', (answer) => {
+            if (answer.toLowerCase() === 'no') {
+                console.log("Canceled");
+                console.log("Your MarketAid can be found at: ", userMarketAidAddress);
+                console.log("Use npm run aid to manage your aid and deposit/withdraw funds");
+                resolve("no");
+            } else {
+                resolve("yes")
+            }
+        })
+    });
+}
 
 // Function 
 export async function startGenericMarketMakingBot(configuration: BotConfiguration, rl?: any, providedMarketAidAddress?: string) {
@@ -387,6 +402,13 @@ export async function startGenericMarketMakingBot(configuration: BotConfiguratio
         console.log("\n This is my contract's address: ", marketAidContractInstance.address);
     }
 
+    const confirmation = await userConfirmStart(rl, userMarketAidAddress)
+    if (confirmation === "yes") {
+        console.log("Starting strat")
+    } else {
+        process.exit(1)
+    }
+
     // 2. Depending on the user's selected strategy, create the strategy and pass it to the bot
     // Configure relevant liquidity venues and use those to generate a live feed of a TARGET simple book
     var referenceLiquidityVenue = new UniswapLiquidityVenue(
@@ -411,7 +433,6 @@ export async function startGenericMarketMakingBot(configuration: BotConfiguratio
         configuration.network == 10 ? process.env.MY_LIVE_BOT_EOA_ADDRESS_OR_REF : process.env.MY_TEST_BOT_EOA_ADDRESS // TODO: hacky
     );
 
-    // 4. Start the bot and listen to log feed
     await bot.launchBot();
 }
 

--- a/executionClients/marketMaking/index.ts
+++ b/executionClients/marketMaking/index.ts
@@ -1,21 +1,15 @@
 import * as dotenv from "dotenv";
-
 import { ethers, BigNumber } from "ethers";
 import { BotConfiguration, BotType, MarketMakingStrategy, tokenList } from "../../configuration/config";
 import { getAddress } from "ethers/lib/utils";
-import MARKET_AID_INTERFACE from "../../configuration/abis/MarketAid";
+import { MARKET_AID_INTERFACE } from "../../configuration/abis/MarketAid";
 import { RiskMinimizedStrategy } from "../../strategies/marketMaking/riskMinimizedUpOnly";
 import { UniswapLiquidityVenue } from "../../liquidityVenues/uniswap";
 import { GenericMarketMakingBot } from "./GenericMarketMakingBot";
-//imports from marketaid
-import { rl, getAidFactory, networkMenu, aidFactoryMenu, maxApproveMarketAidForAllTokens, getTokensByNetwork, switchNetwork } from "../../configuration/marketAid"; //grabbing marketAid functions
-import { MarketAidFactory } from "../../utilities/contracts/MarketAidFactory";
+import { rl, getAidFactory, maxApproveMarketAidForAllTokens, getTokensByNetwork } from "../../configuration/marketAid";
 import { MarketAid } from "../../utilities/contracts/MarketAid";
-//
-//importing to get the right tokens for approval
 import { TokenInfo } from "@uniswap/token-lists";
 import { ERC20 } from "../../utilities/contracts/ERC20";
-//
 import { start } from "repl";
 dotenv.config();
 
@@ -39,7 +33,7 @@ function userMarketAidCheckCallback(configuration: BotConfiguration, rl): Promis
     });
 }
 
-
+// custom deposit menu formatted to work with the rest of the guidedStart
 async function depositMenu(tokens: TokenInfo[], marketAid: MarketAid, rl) {
     const depositAssets: string[] = [];
     const depositAmounts: BigNumber[] = [];
@@ -117,8 +111,7 @@ async function depositMenu(tokens: TokenInfo[], marketAid: MarketAid, rl) {
 
 
 // helper function that lets a user create a MarketAid contract 
-// NOTE: there are different ways to implement this function. I chose this way due to the setup of marketAid.ts
-//  Currently I'm picking pieces from marketAid.ts 
+// marketAid.ts dependancies
 async function helpUserCreateNewMarketAidInstance(configuration: BotConfiguration) {
     //creating token states to pull them for different networks
     let tokens: TokenInfo[] = [];
@@ -147,7 +140,7 @@ async function helpUserCreateNewMarketAidInstance(configuration: BotConfiguratio
     await maxApproveMarketAidForAllTokens(erc20Tokens, marketAid, configuration.connections.signer);
     console.log("Tokens approved!")
     //step 5 - deposit assets
-    //TODO: is there a better approach than doing this?
+    //TODO: add a balance viewer and allow the user to access the market aid menu before the rest of the strategy starts
     await depositMenu(tokens, marketAid, rl)
     return newMarketAidAddress;
 }


### PR DESCRIPTION
## Description

The `guidedStart` flow abstracts the technicalities of launching a strategy and allows a user to quickly get started on Rubicon. Currently, the flow is bricked and does not let the user get past the first step of choosing a strategy.  This PR un-bricks the guidedStart flow and reworks the functionality to give the user the ability to generate and tinker with their `MarketAid` before they launch their strategy. 

## Roadmap (flow for guidedStart)

- [x] Allows user to choose a strategy and choose between all 6 potential networks 
- [x] Allows user to generate a new `MarketAid` and approve the tokens that are associated with that network
- [x] Allows user to deposit tokens 
- [x] Display the balances
- [x] Display the menu for managing the aid 
- [x] User can use an existing market aid and access menu before the strategy is ran
- [x] Final approval before the strategy starts running
- [x] Add relevant details to README