### PR TITLE
Param hotfix: risk premium

### DIFF
--- a/executionClients/marketMaking/README.md
+++ b/executionClients/marketMaking/README.md
@@ -4,18 +4,10 @@
 
 To start the Market Making Bot, use the following command:
 ```
-yarn run startGenericMarketMakingBot -- <ChainID> <MarketAidContractAddress> <Strategy> <Asset> <Quote>
+yarn run startGenericMarketMakingBot startGenericMarketMakingBot <ChainID> <MarketAidContractAddress> <Strategy> <Asset> <Quote> <Premium>
 ```
 
 Note that you can use `yarn run startGenericMarketMakingBot -- PARAMS` to start the bot with custom configurations. Replace `PARAMS` with the specific parameters you need for the bot you want to run. This approach avoids the need for guidedStart and allows bot processes to be quickly spun up in the cloud for operators.
-
-
-The API for the `MarketMakingBot` command-line parameters is as follows:
-API with the following hierarchy of arguments:
-
-```
-yarn run startMarketMakingBot -- <executionClient> <chainId> <marketAidContractAddress> <asset> <quote> <premium>
-```
 
 ### Parameters
 - `<executionClient>`: Notify type of execution client first
@@ -33,9 +25,8 @@ yarn run startMarketMakingBot -- <executionClient> <chainId> <marketAidContractA
 
 ### Example
 ```
-yarn run startMarketMakingBot -- 1 0xMarketAidAddress 0xAssetAddress 0xQuoteAddress
+yarn run startGenericMarketMakingBot startGenericMarketMakingBot <ChainID (ex. 80001)> 0xMarketAidAddress riskminimized/targetvenueoutbid 0xAssetAddress 0xQuoteAddress <Premium (ex. 0.01)>
 ```
-
 
 ## Starting a Batch Executing Bot
 The batch executing bot is designed to execute multiple market making strategies concurrently, optimizing gas usage by batching transactions. This guide will explain how to start a batch executing bot, how strategies are passed through, and how liquidity allocation works.

--- a/executionClients/marketMaking/index.ts
+++ b/executionClients/marketMaking/index.ts
@@ -270,14 +270,6 @@ async function startGenericMarketMakingBotFromArgs(): Promise<void> {
 async function main(): Promise<void> {
     console.log("This is process.argv", process.argv);
 
-    console.log("This is process.argv[2]", process.argv[2])
-    console.log("This is process.argv[3]", process.argv[3])
-    console.log("This is process.argv[4]", process.argv[4])
-    console.log("This is process.argv[5]", process.argv[5])
-    console.log("This is process.argv[6]", process.argv[6])
-    console.log("This is process.argv[7]", process.argv[7])
-    console.log("This is process.argv[8]", process.argv[8])
-
     const command = process.argv[2];
     switch (command) {
         case 'startGenericMarketMakingBot':

--- a/executionClients/marketMaking/index.ts
+++ b/executionClients/marketMaking/index.ts
@@ -245,7 +245,7 @@ async function startGenericMarketMakingBotFromArgs(): Promise<void> {
     if (!quoteTokenInfo) throw new Error(`No token found for address ${quote} on network ${chainId}`);
 
     // Read the premium value from the command line arguments
-    const premium = parseFloat(process.argv[7]);
+    const premium = parseFloat(process.argv[8]);
     if (!premium) throw new Error('No premium value found in process.argv');
 
     var config = {
@@ -269,6 +269,14 @@ async function startGenericMarketMakingBotFromArgs(): Promise<void> {
 
 async function main(): Promise<void> {
     console.log("This is process.argv", process.argv);
+
+    console.log("This is process.argv[2]", process.argv[2])
+    console.log("This is process.argv[3]", process.argv[3])
+    console.log("This is process.argv[4]", process.argv[4])
+    console.log("This is process.argv[5]", process.argv[5])
+    console.log("This is process.argv[6]", process.argv[6])
+    console.log("This is process.argv[7]", process.argv[7])
+    console.log("This is process.argv[8]", process.argv[8])
 
     const command = process.argv[2];
     switch (command) {


### PR DESCRIPTION
updates the `index.ts` file to properly read the `premium` param when running `startGenericMarketMakingBot` through the `cli`. updates `README` to current `api` format